### PR TITLE
fix: auto-remove hotkeys when deleting associated sound

### DIFF
--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -89,7 +89,6 @@ pub fn get_sound_id<'a>(mappings: &'a HotkeyMappings, hotkey: &str) -> Option<&'
 }
 
 /// Get all hotkeys assigned to a specific sound
-#[allow(dead_code)]
 pub fn get_hotkeys_for_sound(mappings: &HotkeyMappings, sound_id: &SoundId) -> Vec<String> {
     mappings
         .mappings


### PR DESCRIPTION
## Problem

- Deleting a sound left orphaned hotkey mappings in `hotkeys.json`
- Caused "already assigned" errors when reassigning the hotkey
- `cleanup_orphaned_hotkeys()` only ran on app startup

## Solution

- `delete_sound` command now removes associated hotkeys before deleting sound
- Unregisters global shortcuts and updates mappings atomically
- Uses existing `get_hotkeys_for_sound()` helper (removed dead_code annotation)

## Backend (Rust)

- Enhanced `commands/sounds.rs::delete_sound` with hotkey cleanup
- Removed `#[allow(dead_code)]` from `hotkeys.rs::get_hotkeys_for_sound`
- Added proper error logging for failed unregister/remove operations

## Test Plan

- [x] Create sound with hotkey assignment
- [x] Delete sound
- [x] Verify hotkey is removed from mappings
- [x] Verify hotkey can be reassigned without error
- [x] Verify logs show "Removing X hotkey(s) for deleted sound"