### PR TITLE
fix: normalize Digit and Key prefixes in hotkey strings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,10 @@ fn normalize_hotkey_string(hotkey: &str) -> String {
                 key if key.starts_with("numpad") => {
                     format!("NumPad{}", capitalize_first(&key[6..]))
                 }
+                // Handle Digit keys: digit0 -> 0, digit1 -> 1, etc.
+                key if key.starts_with("digit") => key[5..].to_string(),
+                // Handle Key prefix: keya -> A, keyb -> B, etc.
+                key if key.starts_with("key") => key[3..].to_uppercase(),
                 // Capitalize first letter for all other keys
                 other => capitalize_first(other),
             }


### PR DESCRIPTION
## Problem

- OS sends keyboard codes like `control+Digit1` or `shift+KeyA`
- Normalization converted these to `Ctrl+Digit1` instead of `Ctrl+1`
- Hotkeys with number/letter keys didn't trigger sounds

## Solution

- Handle `digit` prefix: digit0 → 0, digit1 → 1, etc.
- Handle `key` prefix: keya → A, keyb → B, etc.

## Backend (Rust)

- Extended `normalize_hotkey_string()` in `lib.rs`

## Test Plan

- [x] Assign hotkey with number key (e.g., Ctrl+1)
- [x] Press hotkey → sound triggers correctly
- [x] Manually tested playback