### PR TITLE
fix: system tray close behavior

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,6 +375,26 @@ pub fn run() {
 
             Ok(())
         })
+        .on_window_event(|window, event| {
+            // Handle window close button based on minimize_to_tray setting
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let app = window.app_handle();
+                let state = app.state::<AppState>();
+                let settings = state.read_settings();
+                let minimize_to_tray = settings.minimize_to_tray;
+                drop(settings);
+
+                if minimize_to_tray {
+                    // Minimize to tray instead of closing
+                    api.prevent_close();
+                    let _ = window.hide();
+                    info!("Window minimized to tray (X button)");
+                } else {
+                    // Allow normal close
+                    info!("Window closing (minimize_to_tray disabled)");
+                }
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useState } from "react";
 import Dashboard from "./components/dashboard/Dashboard";
 import Settings from "./components/settings/Settings";
 import ErrorBoundary from "./components/common/ErrorBoundary";
@@ -9,55 +8,20 @@ import {
   SoundLibraryProvider,
   useSoundLibrary,
 } from "./contexts/SoundLibraryContext";
-import { DEBUG } from "./constants";
 
 type View = "dashboard" | "settings";
 
 function AppContent() {
   const [currentView, setCurrentView] = useState<View>("dashboard");
-  const { settings, isLoading: settingsLoading } = useSettings();
+  const { isLoading: settingsLoading } = useSettings();
   const { isLoading: soundsLoading } = useSoundLibrary();
 
   // Dashboard-specific state that persists across view changes
   const [dashboardDevice1, setDashboardDevice1] = useState<string>("");
   const [dashboardDevice2, setDashboardDevice2] = useState<string>("");
 
-  // Handle window close event based on minimize_to_tray setting
-  useEffect(() => {
-    if (!settings) return;
-
-    const window = getCurrentWindow();
-    if (DEBUG)
-      console.log(
-        "Setting up close handler, minimize_to_tray:",
-        settings.minimize_to_tray
-      );
-
-    const unlisten = window.onCloseRequested(async (event) => {
-      if (DEBUG)
-        console.log(
-          "Close event received! minimize_to_tray:",
-          settings.minimize_to_tray
-        );
-
-      if (settings.minimize_to_tray) {
-        event.preventDefault();
-        try {
-          await window.hide();
-          if (DEBUG) console.log("Window minimized to tray via X button");
-        } catch (err) {
-          console.error("Failed to hide window:", err);
-        }
-      } else {
-        if (DEBUG)
-          console.log("Window closing normally (minimize_to_tray is disabled)");
-      }
-    });
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [settings?.minimize_to_tray]);
+  // Note: Window close behavior (minimize to tray vs quit) is handled
+  // in the Rust backend via on_window_event for consistent behavior
 
   // Show loading state while contexts initialize
   if (settingsLoading || soundsLoading) {


### PR DESCRIPTION
## Summary

- Move close policy from Frontend to Backend for consistent behavior
- X-Button now correctly closes app when "Minimize to tray" is disabled
- Eliminates race condition from async settings load

## Changes

**Problem:**
- X-Button did nothing when "Minimize to tray" was disabled
- Frontend handler waited for async settings load (race condition)

**Solution:**
- Add `on_window_event` handler in Backend (lib.rs)
- Backend reads settings from AppState (already loaded at startup)
- Remove redundant Frontend handler

## Files Changed

- `src-tauri/src/lib.rs` - Add on_window_event handler for CloseRequested
- `src/App.tsx` - Remove onCloseRequested handler (now handled by Backend)

## Test Plan

- [x] "Minimize to tray" OFF → X-Button closes app
- [x] "Minimize to tray" ON → X-Button minimizes to tray