### PR TITLE
feat: add low-latency audio with fixed buffer size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ release//
 /src-tauri/Cargo.lock
 /src-tauri/WixTools/
 /src-tauri/gen/
+prs.json
 
 # Node / Yarn
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ SonicDeck is a high-performance desktop soundboard application built with:
 - `cargo fmt` standard formatting
 - `snake_case` for functions/variables
 - `///` doc comments for public functions
+- `///` doc comments for complex private functions (>20 lines or non-trivial logic)
 - Explicit error handling - avoid `unwrap()` in production
 - Use `tracing` for logging (see Logging section)
 


### PR DESCRIPTION
## Summary
- Set BufferSize::Fixed(256) for ~5.3ms buffer latency @ 48kHz
- Add fallback strategy (256 → 512 → 1024 → Default) for device compatibility
- Log used buffer size for debugging

## Changes

### Backend (Rust)
- Add `PREFERRED_BUFFER_SIZE` constant (256 samples)
- Refactor stream creation into `build_stream_with_fallback()`
- Add `try_build_stream()` helper for cleaner fallback logic
- Log `buffer_size` in stream creation info message

## Manual Testing

### Devices Tested (4 total):

| Device | Sample Rate | Channels | Buffer Size | Latency | Stream Creation |
|--------|-------------|----------|-------------|---------|-----------------|
| **Logitech G935/G933s Gaming Headset** | 48kHz | 8 | Fixed(256) ✓ | ~5.33ms | 19ms |
| **CABLE Input (VB-Audio Virtual Cable)** | 192kHz | 2 | Fixed(256) ✓ | ~1.33ms | 6-7ms |
| **Lautsprecher (USB Audio CODEC)** | 48kHz | 2 | Fixed(256) ✓ | ~5.33ms | 22-25ms |
| **Kopfhörer (Galaxy Buds2 Pro)** (Bluetooth) | 48kHz | 2 | Fixed(256) ✓ | ~5.33ms | 9ms |

### Results:
- ✅ **4/4 devices support low-latency buffer** (256 samples)
- ✅ **No fallback required** - all devices accept preferred buffer size
- ✅ **Multi-channel device tested** (8-channel 7.1 gaming headset)
- ✅ **Bluetooth device tested** (Galaxy Buds2 Pro)
- ✅ **High sample rate tested** (192kHz virtual cable)
- ✅ **USB audio device tested** (USB Audio CODEC)
- ✅ **No audio glitches or artifacts** on any device
- ✅ **Dual-output routing** functioning properly on all combinations

### Test Plan Status:
- [x] Sound plays normally with Fixed(256)
- [x] Buffer size logged: `buffer_size="Fixed(256)"`
- [x] No audio glitches on different hardware (tested on 4 devices)
- [x] Multi-channel device tested (8-channel gaming headset)
- [x] High sample rate tested (192kHz virtual cable)
- [x] Bluetooth device tested (Galaxy Buds2 Pro)
- [ ] Fallback mechanism not explicitly tested (all devices support 256 buffer)

### Notes:
- **Latency calculation**: `buffer_size / sample_rate * 1000ms`
  - Example: 256 / 48000 * 1000 = 5.33ms
  - At 192kHz: 256 / 192000 * 1000 = 1.33ms (extremely low!)
- Multi-channel mapping working correctly (8 output channels, 2 input channels → extra channels silenced)