### PR TITLE
chore: add sample rate conversion logging for quality analysis

### DIFF
--- a/src-tauri/src/audio/playback.rs
+++ b/src-tauri/src/audio/playback.rs
@@ -62,6 +62,16 @@ pub fn create_playback_stream(
     // Calculate sample rate ratio for resampling
     let rate_ratio = audio_data.sample_rate as f64 / output_sample_rate as f64;
 
+    // Log if resampling is occurring (quality impact)
+    if audio_data.sample_rate != output_sample_rate {
+        info!(
+            audio_sample_rate = audio_data.sample_rate,
+            output_sample_rate = output_sample_rate,
+            rate_ratio = format!("{:.4}", rate_ratio),
+            "Sample rate conversion active"
+        );
+    }
+
     // Try to build stream with low-latency config, fallback to default if it fails
     let (stream, used_buffer_size) = build_stream_with_fallback(
         device,


### PR DESCRIPTION
## Summary
Adds INFO-level logging when sample rate conversion (resampling) occurs. Helps identify when audio quality might be impacted by resampling.

## Changes
- Add condition after rate_ratio calculation (playback.rs:66-73)
- Only logs when audio_sample_rate ≠ output_sample_rate (no spam)
- INFO level (visible in Production logs when relevant)

## Example Log
```
INFO Sample rate conversion active audio_sample_rate=44100 output_sample_rate=48000 rate_ratio="0.9188"
```

## Impact
- **Production:** Only logs when resampling actually occurs (quality-relevant info)
- **No spam:** Silent when sample rates match (most common case)
- **Debugging:** Helps identify audio quality issues caused by resampling