### PR TITLE
perf: Memoize SoundButton to prevent unnecessary re-renders

### DIFF
--- a/src/components/dashboard/SoundButton.tsx
+++ b/src/components/dashboard/SoundButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, memo } from "react";
 import { Sound, HotkeyMapping } from "../../types";
 import HotkeyManager from "../modals/HotkeyManager";
 import { formatHotkeyForDisplay } from "../../utils/hotkeyDisplay";
@@ -17,7 +17,7 @@ interface SoundButtonProps {
   onHotkeyChanged: () => void;
 }
 
-export default function SoundButton({
+function SoundButtonComponent({
   sound,
   isPlaying,
   onPlay,
@@ -201,3 +201,6 @@ export default function SoundButton({
     </div>
   );
 }
+
+const SoundButton = memo(SoundButtonComponent);
+export default SoundButton;


### PR DESCRIPTION
## Problem
- Clicking one sound caused all ~50 SoundButton components to re-render
- Props rarely change (only when clicking/right-clicking specific button)
- Unnecessary re-renders impact performance with many sounds

## Solution
- Added `React.memo()` wrapper to SoundButton component
- Renamed to `SoundButtonComponent` internally
- Exported memo-wrapped version (same pattern as MiniWaveform)

## Changes
**Frontend (React):**
- `src/components/dashboard/SoundButton.tsx`: Added memo import and wrapper

## Testing
- [X] TypeScript compilation passed
- [X] Pre-commit hooks passed (lint, format, typecheck, Rust check)